### PR TITLE
Update Datadog agent and operator versions

### DIFF
--- a/regional/manifests/variables.tofu
+++ b/regional/manifests/variables.tofu
@@ -210,7 +210,7 @@ variable "node_agent_requests_memory" {
 variable "node_agent_tag" {
   description = "Tag for the Datadog node agent image"
   type        = string
-  default     = "7.67.1"
+  default     = "7.70.0"
 }
 
 variable "node_agent_tolerations" {

--- a/regional/variables.tofu
+++ b/regional/variables.tofu
@@ -39,7 +39,7 @@ variable "limits_memory" {
 variable "operator_version" {
   description = "The version of the Datadog Operator to install"
   type        = string
-  default     = "2.11.1"
+  default     = "2.12.1"
 }
 
 variable "requests_cpu" {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded default Datadog node agent version to 7.70.0 for new deployments, bringing the latest performance and security improvements.
  * Bumped default operator version to 2.12.1 to align with recent stability and compatibility updates.
  * Existing configurations that rely on defaults will automatically adopt these newer versions on rollout; pinned versions are unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->